### PR TITLE
fix(server): correct timezone handling in seconds_from_now function

### DIFF
--- a/src/server/api/memobase_server/utils.py
+++ b/src/server/api/memobase_server/utils.py
@@ -57,8 +57,7 @@ def get_blob_token_size(blob: Blob):
 
 
 def seconds_from_now(dt: datetime):
-    return (datetime.now(tz=timezone.utc) - dt.replace(tzinfo=timezone.utc)).seconds
-
+    return (datetime.now(tz=timezone.utc) - dt.astimezone(timezone.utc)).seconds
 
 def user_id_lock(scope):
     def __user_id_lock(func):


### PR DESCRIPTION
- Replace `dt.replace(tzinfo=timezone.utc)` with `dt.astimezone(timezone.utc)`
- This change ensures accurate timezone conversion and prevents potential errors