### PR TITLE
feat(typescript SDK): add user event method

### DIFF
--- a/src/client/memobase-ts/src/types.ts
+++ b/src/client/memobase-ts/src/types.ts
@@ -113,3 +113,24 @@ export const ProfileResponse = z.object({
   ),
 });
 export type ProfileResponse = z.infer<typeof ProfileResponse>;
+
+export const EventResponse = z.object({
+  events: z.array(
+    z.object({
+      id: z.string(),
+      event_data: z
+        .object({
+          profile_delta: z
+            .object({
+              content: z.string(),
+              attributes: z.record(z.any()),
+            })
+            .nullable(),
+        })
+        .nullable(),
+      created_at: z.coerce.date(),
+      updated_at: z.coerce.date(),
+    }),
+  ),
+});
+export type EventResponse = z.infer<typeof EventResponse>;

--- a/src/client/memobase-ts/src/user.ts
+++ b/src/client/memobase-ts/src/user.ts
@@ -1,5 +1,5 @@
 import { MemoBaseClient } from './client';
-import type { Blob, BlobType, UserProfile, IdResponse, ProfileResponse } from './types';
+import { Blob, BlobType, UserProfile, IdResponse, ProfileResponse, EventResponse } from './types';
 
 export class User {
   constructor(
@@ -55,5 +55,27 @@ export class User {
   async deleteProfile(profileId: string): Promise<boolean> {
     await this.projectClient.fetch(`/users/profile/${this.userId}/${profileId}`, { method: 'DELETE' });
     return true;
+  }
+
+  /**
+   * Returns a list of the user’s most recent events, ordered by recency
+   * docs: https://docs.memobase.io/api-reference/events/get_events#response-data-events-created-at
+   * @param userId - The user ID
+   * @param topk - The number of events to return
+   * @param max_token_size - The maximum token size
+   * @returns The events for the user
+   */
+  async event(
+    userId: string,
+    { topk, max_token_size }: { topk?: number; max_token_size?: number } = {},
+  ): Promise<EventResponse> {
+    const params = new URLSearchParams();
+    if (topk != null) params.set('topk', topk.toString());
+    if (max_token_size != null) params.set('max_token_size', max_token_size.toString());
+    const queryParams = params.toString();
+    let path = `/users/event/${userId}`;
+    if (queryParams) path += `?${queryParams}`;
+    const response = await this.projectClient.fetch<EventResponse>(path);
+    return EventResponse.parse(response.data);
   }
 }

--- a/src/client/memobase-ts/tsconfig.json
+++ b/src/client/memobase-ts/tsconfig.json
@@ -7,16 +7,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "node"]
   },
-  "include": [
-    "index.ts",
-    "src/**/*",
-    "tests/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "tests/**/*"
-  ]
+  "include": ["index.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# Description

Support the API user event method to fetch the recent events for a user in the Typescript SDK.

# Notes
- use a new EventResponse Zod schema to parse string dates into JS Date from the API response
- add unit tests to check correct support of query params and response parsing with Zod
- the new `event` function arguments follow the idiomatic Typescript way of providing options (as an object rather than successive function arguments), but it's not aligned with the existing getAll method.