### PR TITLE
Chore/optimize dockerfile

### DIFF
--- a/src/server/api/Dockerfile
+++ b/src/server/api/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.11-slim-buster AS build
 
-
 WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
-RUN python3.11 -m pip install -r requirements.txt --no-cache-dir
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3.11 -m pip install --no-cache-dir -r requirements.txt
 
 COPY ./memobase_server /app/memobase_server
 COPY ./api.py /app
 COPY ./api_docs.py /app
-
 
 CMD ["python3.11", "-m", "fastapi", "run", "api.py"]

--- a/src/server/api/api.py
+++ b/src/server/api/api.py
@@ -38,7 +38,7 @@ def custom_openapi():
         routes=app.routes,
         servers=[
             {"url": "https://api.memobase.dev"},
-            {"url": "https://api.memboase.cn"},
+            {"url": "https://api.memobase.cn"},
         ],
     )
     openapi_schema["components"]["securitySchemes"] = {


### PR DESCRIPTION
    
Tried `docker ai` to optimize dockerfile

 Added a Build Cache for pip:
* The RUN command for installing Python dependencies now includes the
  --mount=type=cache,target=/root/.cache/pip option.
 * This optimization uses Docker's build cache to store and reuse the pip cache across builds.
  While the --no-cache-dir flag ensures that no unnecessary files are left in the final image, the
  --mount=type=cache ensures that the pip cache is available during the build process to speed up dependency
  installation in subsequent builds.
* This is particularly useful in development workflows where dependencies do not change
  frequently, as it avoids re-downloading the same packages every time the image is rebuilt.


Why This Matters
* Performance: By caching the pip downloads, the build process becomes faster, especially when
  rebuilding the image multiple times with unchanged dependencies.
* Efficiency: The --no-cache-dir flag ensures that the final image remains small, while the
  --mount=type=cache ensures that the build process is efficient without bloating the image.
*  Best Practices: Leveraging Docker's build cache is a best practice for optimizing Dockerfiles,
  especially for dependency-heavy applications.
