### PR TITLE
fix: optimize docker file

### DIFF
--- a/src/server/api/Dockerfile
+++ b/src/server/api/Dockerfile
@@ -11,4 +11,4 @@ COPY ./api.py /app
 COPY ./api_docs.py /app
 
 
-CMD ["python3.11", "-m", "fastapi", "run", "api.py"]
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--proxy-headers"]


### PR DESCRIPTION
- [x] Use uvicorn to launch fastapi with multi-worker
- [ ] Reduce image size (multi-stage building)
- [ ] Fix problems for new launching method



## Maybe Issues
- Prometheus HTTP server error when Init:
```
WARNING Prometheus HTTP server already running on port
```
