### PR TITLE
feat(py-sdk): add support for the max_token_size & need_summary parameters of the event method

### DIFF
--- a/docs/site/openapi.json
+++ b/docs/site/openapi.json
@@ -1246,6 +1246,18 @@
 							"title": "Max Token Size"
 						},
 						"description": "Max token size of returned events"
+					},
+					{
+						"name": "need_summary",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "boolean",
+							"description": "Whether to require event summary in returned events",
+							"default": false,
+							"title": "Need Summary"
+						},
+						"description": "Whether to require event summary in returned events"
 					}
 				],
 				"responses": {

--- a/src/client/memobase/core/async_entry.py
+++ b/src/client/memobase/core/async_entry.py
@@ -238,10 +238,15 @@ class AsyncUser:
         )
         return True
 
-    async def event(self, topk=10) -> list[UserEventData]:
+    async def event(self, topk=10, max_token_size=None, need_summary=False) -> list[UserEventData]:
+        params = f"?topk={topk}"  
+        if max_token_size is not None:  
+            params += f"&max_token_size={max_token_size}"  
+        if need_summary:  
+            params += f"&need_summary=true"
         r = unpack_response(
             await self.project_client.client.get(
-                f"/users/event/{self.user_id}?topk={topk}"
+                f"/users/event/{self.user_id}{params}"
             )
         )
         return [UserEventData.model_validate(e) for e in r.data["events"]]

--- a/src/client/memobase/core/entry.py
+++ b/src/client/memobase/core/entry.py
@@ -219,9 +219,14 @@ class User:
         )
         return True
 
-    def event(self, topk=10) -> list[UserEventData]:
+    def event(self, topk=10, max_token_size=None, need_summary=False) -> list[UserEventData]:
+        params = f"?topk={topk}"  
+        if max_token_size is not None:  
+            params += f"&max_token_size={max_token_size}"  
+        if need_summary:  
+            params += f"&need_summary=true"
         r = unpack_response(
-            self.project_client.client.get(f"/users/event/{self.user_id}?topk={topk}")
+            self.project_client.client.get(f"/users/event/{self.user_id}{params}")
         )
         return [UserEventData.model_validate(e) for e in r.data["events"]]
 

--- a/src/server/api/api_docs.py
+++ b/src/server/api/api_docs.py
@@ -860,8 +860,9 @@ API_X_CODE_DOCS["GET /users/event/{user_id}"] = {
 from memobase import Memobase
 
 client = Memobase(project_url='PROJECT_URL', api_key='PROJECT_TOKEN')
+u = client.get_user(uid)
 
-events = u.event(topk=10, max_token_size=1000)
+events = u.event(topk=10, max_token_size=1000, need_summary=True)
 """,
             "label": "Python",
         },

--- a/src/server/api/memobase_server/api_layer/event.py
+++ b/src/server/api/memobase_server/api_layer/event.py
@@ -12,10 +12,14 @@ async def get_user_events(
         None,
         description="Max token size of returned events",
     ),
+    need_summary: bool = Query(
+        False,
+        description="Whether to return events with summaries",
+    ),
 ) -> res.UserEventsDataResponse:
     project_id = request.state.memobase_project_id
     p = await controllers.event.get_user_events(
-        user_id, project_id, topk=topk, max_token_size=max_token_size
+        user_id, project_id, topk=topk, max_token_size=max_token_size, need_summary=need_summary
     )
     return p.to_response(res.UserEventsDataResponse)
 


### PR DESCRIPTION
Add support for the max_token_size and need_summary parameters to the User.event() and AsyncUser.event() methods in the Python SDK.
This will make them consistent with the backend API.