### PR TITLE
Create vector extension

### DIFF
--- a/assets/tutorials/livekit+memobase/requirements.txt
+++ b/assets/tutorials/livekit+memobase/requirements.txt
@@ -1,3 +1,4 @@
 livekit-plugins-noise-cancellation
 livekit-agents[openai,silero,turn-detector,deepgram,noise_cancellation]
 memobase
+python-dotenv

--- a/src/server/api/memobase_server/connectors.py
+++ b/src/server/api/memobase_server/connectors.py
@@ -34,7 +34,19 @@ REDIS_POOL = None
 Session = sessionmaker(bind=DB_ENGINE)
 
 
+def create_pgvector_extension():
+    try:
+        with Session() as session:
+            session.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+            session.commit()
+            LOG.info("pgvector extension created or already exists")
+    except Exception as e:
+        LOG.error(f"Failed to create pgvector extension: {e}")
+
+
 def create_tables():
+    create_pgvector_extension()
+    
     REG.metadata.create_all(DB_ENGINE)
     with Session() as session:
         Project.initialize_root_project(session)


### PR DESCRIPTION
When deploying Memobase in the cloud using a managed PostgreSQL service like RDS, direct execution of initialization SQL (e.g., CREATE EXTENSION) is not allowed.  A workaround is possible, such as using a Lambda function to execute the initial SQL, but this adds complexity to the deployment process.

Therefore, it's more practical to create the extension at the code level.