### PR TITLE
Add auto-instrumentation for fastapi

### DIFF
--- a/src/server/api/api.py
+++ b/src/server/api/api.py
@@ -16,6 +16,8 @@ from memobase_server.env import LOG
 from memobase_server.llms.embeddings import check_embedding_sanity
 from uvicorn.config import LOGGING_CONFIG
 from api_docs import API_X_CODE_DOCS
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
 
 
 @asynccontextmanager
@@ -259,3 +261,5 @@ router.post(
 
 app.include_router(router)
 app.add_middleware(api_layer.middleware.AuthMiddleware)
+
+FastAPIInstrumentor.instrument_app(app)

--- a/src/server/api/requirements.txt
+++ b/src/server/api/requirements.txt
@@ -13,5 +13,6 @@ volcengine-python-sdk[ark]
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-prometheus
+opentelemetry-instrumentation-fastapi
 typeguard
 taskiq


### PR DESCRIPTION
Add an instrumentation library for FastAPI; the [metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md) are automatically generated.
The status code is in the metric dimension, which makes it easy to set up some alarms.