### PR TITLE
Update README.md

### DIFF
--- a/docs/experiments/locomo-benchmark/README.md
+++ b/docs/experiments/locomo-benchmark/README.md
@@ -118,7 +118,7 @@ py generate_scores.py --input_path="evals.json"
 **Deps**
 
 ```bash
-pip install mem0
+pip install mem0ai
 ```
 
 **Env**


### PR DESCRIPTION
The `pip install mem0` is now outdated and should use `pip install mem0ai` instead. 😊