### PR TITLE
fix: add missing blob_id index to buffer_zones table

### DIFF
--- a/src/server/api/memobase_server/models/database.py
+++ b/src/server/api/memobase_server/models/database.py
@@ -393,6 +393,11 @@ class BufferZone(Base):
             "blob_type",
             "status",
         ),
+        Index(
+            "idx_buffer_zones_blob_id_project_id",
+            "blob_id",
+            "project_id",
+        ),
         ForeignKeyConstraint(
             ["user_id", "project_id"],
             ["users.id", "users.project_id"],


### PR DESCRIPTION
## Problem

The `buffer_zones` table has a foreign key constraint on `(blob_id, project_id)` referencing `general_blobs`, but there's no index on these columns.

This causes:
- Full table scans during CASCADE DELETE when `general_blobs` records are deleted
- Slow JOIN queries between `BufferZone` and `GeneralBlob`

## Solution

Add index `idx_buffer_zones_blob_id_project_id` on `(blob_id, project_id)` columns.

## Migration

After deploying, run the following SQL to add the index to existing databases:

CREATE INDEX idx_buffer_zones_blob_id_project_id 
ON buffer_zones (blob_id, project_id);## Testing

- [x] Verified the index is created correctly in local development
- [x] Tested CASCADE DELETE performance improvement