### PR TITLE
fix: remove redundant len() call on buffer size

### DIFF
--- a/docs/experiments/900-chats/run.py
+++ b/docs/experiments/900-chats/run.py
@@ -53,8 +53,8 @@ u.flush(sync=True)
 print("Cost time(s)", time() - start)
 
 while True:
-    left = len(u.buffer("chat", "processing"))
-    if len(left):
+    left = u.buffer("chat", "processing")
+    if left:
         print(f"Left {len(left)} chats")
         sleep(1)
     else:


### PR DESCRIPTION
## Problem

The `u.buffer()` method returns a `list[str]` (list of blob IDs). The code incorrectly calls `len()` twice:
- First `len(u.buffer(...))` makes `left` an integer
- Then `len(left)` tries to call `len()` on an integer, causing `TypeError`

## Solution

Remove the redundant `len()` call, keeping `left` as the count directly. Use `left` in the condition and print statement.

## Testing

- [x] Verified the buffer API returns `list[str]`
- [x] Code now properly checks and displays the remaining buffer count