### PR TITLE
fix: remove max_tokens for llm

### DIFF
--- a/src/server/api/memobase_server/llms/__init__.py
+++ b/src/server/api/memobase_server/llms/__init__.py
@@ -24,7 +24,6 @@ async def llm_complete(
     history_messages=[],
     json_mode=False,
     model=None,
-    max_tokens=1024,
     **kwargs,
 ) -> Promise[str | dict]:
     use_model = model or CONFIG.best_llm_model
@@ -37,7 +36,6 @@ async def llm_complete(
             prompt,
             system_prompt=system_prompt,
             history_messages=history_messages,
-            max_tokens=max_tokens,
             **kwargs,
         )
         latency = (time.time() - start_time) * 1000


### PR DESCRIPTION
原始max_tokens 被限制在了1024，这对于国内的一些模型会出现问题。
比如我使用智谱的glm 4.6时，会开启思考模式，思考过程也会占用token，当思考的token大于1024时，得到的回复结果会是一个空字符串。 

所以提取profile 和 提取memory时就非常的不稳定，有的时候可以提取出来，有的时候则不能。

我去掉max_tokens限制之后，一切都运行的很好。

建议删除max_tokens的限制，应该优先保证使用效果，而不是控制成本（通过这种方式控制成本感觉也不太对）。